### PR TITLE
removed internal modifier

### DIFF
--- a/YoLo.fs
+++ b/YoLo.fs
@@ -1,5 +1,5 @@
 [<AutoOpen>]
-module internal YoLo
+module YoLo
 
 #nowarn "64"
 


### PR DESCRIPTION
I am not sure why YoLo module should be internal, but it caused an issue.
