### PR TITLE
Add named equality functions

### DIFF
--- a/YoLo.fs
+++ b/YoLo.fs
@@ -12,6 +12,10 @@ let uncurry f (a, b) = f a b
 
 let flip f a b = f b a
 
+let eq x y = x = y
+    
+let neq x y = x <> y
+
 module Choice =
 
   let create v = Choice1Of2 v


### PR DESCRIPTION
I'm aware you can use `(=)` and `(<>)` to the same effect. But I find them very convenient to use and somewhat easier to read, particularly when partially applied or as point-free.
