### PR TITLE
Add async timeout function

### DIFF
--- a/YoLo.fs
+++ b/YoLo.fs
@@ -485,6 +485,15 @@ module Async =
     return! f x
   }
 
+  let withTimeout (timeoutMillis) operation = 
+    async {
+      let! child = Async.StartChild(operation, timeoutMillis)
+      try 
+        let! result = child
+        return Some result
+      with :? TimeoutException -> return None
+    }
+
   let apply fAsync xAsync = async {
     // start the two asyncs in parallel
     let! fChild = Async.StartChild fAsync


### PR DESCRIPTION
I'm not sure on how you'd prefer to name it, but I tend to use it as
`asyncFunc >> Async.withTimeout 500`, which reads fairly well.